### PR TITLE
Fix ICE candidate SDPMid assignment

### DIFF
--- a/pion-server/main.go
+++ b/pion-server/main.go
@@ -362,10 +362,14 @@ func (s *stream) createPeerConnection(c *client) (*webrtc.PeerConnection, error)
 			v := uint16(*init.SDPMLineIndex)
 			lineIndex = &v
 		}
+		var sdpMid string
+		if init.SDPMid != nil {
+			sdpMid = *init.SDPMid
+		}
 		msg := signalMessage{
 			Type:          "ice",
 			Candidate:     init.Candidate,
-			SDPMid:        init.SDPMid,
+			SDPMid:        sdpMid,
 			SDPMLineIndex: lineIndex,
 		}
 		if err := c.sendSignal(msg); err != nil {


### PR DESCRIPTION
## Summary
- ensure ICE candidate signals unwrap optional SDP mid values before populating the JSON message

## Testing
- `go build ./...` *(fails: missing go.sum entries for websocket, rtcp, webrtc)*

------
https://chatgpt.com/codex/tasks/task_e_68d0933fdaa0832cb886e8d5bf14f757