### PR TITLE
Serve dashboard assets over detection WebSocket port

### DIFF
--- a/jetson/websocket_server.py
+++ b/jetson/websocket_server.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import asyncio
+import http
 import json
-from typing import Optional, Set
+import mimetypes
+from pathlib import Path
+from typing import Optional, Set, Union
 
 import websockets
 from websockets.server import WebSocketServer, WebSocketServerProtocol
@@ -12,17 +15,33 @@ from websockets.server import WebSocketServer, WebSocketServerProtocol
 class DetectionBroadcaster:
     """Simple WebSocket pub-sub helper for detection results."""
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 8765, path: str = "/detections"):
+    def __init__(
+        self,
+        host: str = "0.0.0.0",
+        port: int = 8765,
+        path: str = "/detections",
+        static_dir: Optional[Union[str, Path]] = None,
+    ):
         self._host = host
         self._port = port
         self._path = path
         self._clients: Set[WebSocketServerProtocol] = set()
         self._server: Optional[WebSocketServer] = None
+        if static_dir is None:
+            default_static = Path(__file__).resolve().parents[1] / "browser"
+            self._static_dir = default_static if default_static.exists() else None
+        else:
+            self._static_dir = Path(static_dir).resolve()
 
     async def start(self) -> None:
         if self._server is not None:
             return
-        self._server = await websockets.serve(self._handler, self._host, self._port)
+        self._server = await websockets.serve(
+            self._handler,
+            self._host,
+            self._port,
+            process_request=self._process_http_request,
+        )
 
     async def stop(self) -> None:
         if self._server is None:
@@ -53,4 +72,52 @@ class DetectionBroadcaster:
             await websocket.send(message)
         except Exception:
             self._clients.discard(websocket)
+
+    async def _process_http_request(self, path: str, request_headers):
+        upgrade_header = request_headers.get("Upgrade", "")
+        if "websocket" in upgrade_header.lower():
+            return None
+
+        if self._static_dir is not None:
+            file_path = self._resolve_static_path(path)
+            if file_path is not None:
+                body = file_path.read_bytes()
+                content_type, _ = mimetypes.guess_type(str(file_path))
+                headers = [
+                    ("Content-Type", content_type or "application/octet-stream"),
+                    ("Content-Length", str(len(body))),
+                    ("Cache-Control", "no-cache"),
+                ]
+                return http.HTTPStatus.OK, headers, body
+
+        body = (
+            "Detection broadcaster is running. Connect with a WebSocket client at "
+            f"{self._path}."
+        ).encode("utf-8")
+        headers = [
+            ("Content-Type", "text/plain; charset=utf-8"),
+            ("Content-Length", str(len(body))),
+            ("Cache-Control", "no-cache"),
+        ]
+        return http.HTTPStatus.OK, headers, body
+
+    def _resolve_static_path(self, request_path: str) -> Optional[Path]:
+        if self._static_dir is None:
+            return None
+
+        if request_path in {"", "/"}:
+            candidate = self._static_dir / "dashboard.html"
+        else:
+            relative = request_path.lstrip("/")
+            candidate = (self._static_dir / relative).resolve()
+            try:
+                candidate.relative_to(self._static_dir)
+            except ValueError:
+                return None
+
+        if candidate.is_dir():
+            candidate = candidate / "index.html"
+        if candidate.is_file():
+            return candidate
+        return None
 


### PR DESCRIPTION
## Summary
- add optional static file support to the Jetson detection broadcaster so plain HTTP requests are answered without handshake errors
- provide a fallback message when the WebSocket endpoint is accessed by a regular browser request
- keep WebSocket broadcasts unchanged while allowing the dashboard files to be served from the same port

## Testing
- python -m compileall jetson

------
https://chatgpt.com/codex/tasks/task_e_68d0b34887a0832c9a8bcaf699dd310a