### PR TITLE
Add streaming controls and move Pion config to toolbar menu

### DIFF
--- a/android-application/app/src/main/res/layout/activity_main.xml
+++ b/android-application/app/src/main/res/layout/activity_main.xml
@@ -42,6 +42,106 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/streamingControlCard"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="12dp"
+                app:cardElevation="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/videoRenderer">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:id="@+id/streamingControlTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/streaming_options_title"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/streamingControlDescription"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/streaming_options_description"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+                    <com.google.android.material.button.MaterialButtonToggleGroup
+                        android:id="@+id/streamingSourceToggle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        app:checkedButton="@id/streamSourceDrone"
+                        app:singleSelection="true">
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/streamSourceDrone"
+                            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/streaming_source_drone" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/streamSourceMobile"
+                            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/streaming_source_mobile" />
+
+                    </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/includeGpsSwitch"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:checked="true"
+                        android:text="@string/streaming_option_include_gps"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/includeAudioSwitch"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/streaming_option_include_audio"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                    <TextView
+                        android:id="@+id/streamingSummaryText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+                        tools:text="드론 카메라 • GPS 사용 • 오디오 미사용" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/startStreamingButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="@string/streaming_action_drone"
+                        app:icon="@drawable/ic_videocam"
+                        app:iconPadding="8dp"
+                        app:iconGravity="textStart" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
             <org.osmdroid.views.MapView
                 android:id="@+id/mapView"
                 android:layout_width="0dp"
@@ -50,7 +150,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/videoRenderer" />
+                app:layout_constraintTop_toBottomOf="@+id/streamingControlCard" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/android-application/app/src/main/res/menu/menu_main.xml
+++ b/android-application/app/src/main/res/menu/menu_main.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_action_configure_pion"
+        android:icon="@drawable/ic_settings"
+        android:title="@string/menu_configure_pion"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/android-application/app/src/main/res/menu/menu_settings_drawer.xml
+++ b/android-application/app/src/main/res/menu/menu_settings_drawer.xml
@@ -2,10 +2,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <group android:checkableBehavior="none">
         <item
-            android:id="@+id/menu_configure_pion"
-            android:icon="@drawable/ic_settings"
-            android:title="@string/menu_configure_pion" />
-        <item
             android:id="@+id/menu_open_mobile_stream"
             android:icon="@drawable/ic_videocam"
             android:title="@string/menu_open_mobile_stream" />

--- a/android-application/app/src/main/res/values/strings.xml
+++ b/android-application/app/src/main/res/values/strings.xml
@@ -49,4 +49,16 @@
     <string name="camera_stream_path_status">%1$d개 위치 기록, 총 %2$s 이동</string>
     <string name="camera_stream_distance_meters">%.0f m</string>
     <string name="camera_stream_distance_kilometers">%.2f km</string>
+    <string name="streaming_options_title">스트리밍 제어</string>
+    <string name="streaming_options_description">실시간 영상 공유와 텔레메트리 전송 옵션을 선택하세요.</string>
+    <string name="streaming_source_drone">드론 카메라</string>
+    <string name="streaming_source_mobile">모바일 카메라</string>
+    <string name="streaming_option_include_gps">GPS 데이터 전송</string>
+    <string name="streaming_option_include_audio">마이크 오디오 포함</string>
+    <string name="streaming_summary_format">%1$s • GPS %2$s • 오디오 %3$s</string>
+    <string name="streaming_option_enabled">사용</string>
+    <string name="streaming_option_disabled">미사용</string>
+    <string name="streaming_action_drone">드론 스트림 관리</string>
+    <string name="streaming_action_mobile">모바일 스트림 열기</string>
+    <string name="streaming_action_drone_message">드론 스트리밍은 자동으로 관리됩니다. 필요한 경우 DJI 연결 상태를 확인하세요.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a streaming control card on the main screen with source selection and GPS/Audio toggles
- persist the selected options in MainActivity and update the UI summary/action button accordingly
- move the Pion relay configuration into the toolbar options menu and streamline the settings drawer

## Testing
- ./gradlew :app:lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dce645f4832c8553ac766b881135