### PR TITLE
Refine streaming controls layout

### DIFF
--- a/android-application/app/src/main/java/com/drone/djiwebrtc/CameraStreamActivity.java
+++ b/android-application/app/src/main/java/com/drone/djiwebrtc/CameraStreamActivity.java
@@ -59,7 +59,6 @@ public class CameraStreamActivity extends AppCompatActivity {
     private static final float LOCATION_UPDATE_NETWORK_MIN_DISTANCE_M = 5.0f;
     private static final String STATE_STREAM_ID = "state_stream_id";
     private static final String STATE_CAMERA_INDEX = "state_camera_index";
-    private static final String STATE_CONTROLS_COLLAPSED = "state_controls_collapsed";
     private static final long TELEMETRY_MIN_INTERVAL_MS = 1000L;
 
     private ActivityCameraStreamBinding binding;
@@ -70,7 +69,6 @@ public class CameraStreamActivity extends AppCompatActivity {
 
     private StreamingState streamingState = StreamingState.IDLE;
     private boolean pendingStartAfterPermission = false;
-    private boolean controlsCollapsed = false;
 
     private PionSignalingClient signalingClient;
     private WebRTCClient webRtcClient;
@@ -140,7 +138,6 @@ public class CameraStreamActivity extends AppCompatActivity {
         initialiseCameraEnumerator();
         initialiseStreamIdField(savedInstanceState);
         updateSignalingSummary();
-        setupControlPanelToggle();
 
         routeOverlayManager = new RouteOverlayManager(binding.pathMap);
         routeOverlayManager.initialize();
@@ -276,7 +273,6 @@ public class CameraStreamActivity extends AppCompatActivity {
             return;
         }
         selectedCameraIndex = savedInstanceState.getInt(STATE_CAMERA_INDEX, selectedCameraIndex);
-        controlsCollapsed = savedInstanceState.getBoolean(STATE_CONTROLS_COLLAPSED, controlsCollapsed);
     }
 
     private void initialiseStreamIdField(@Nullable Bundle savedInstanceState) {
@@ -304,29 +300,6 @@ public class CameraStreamActivity extends AppCompatActivity {
             String label = getString(R.string.camera_stream_signaling_url_label);
             binding.signalingUrlValue.setText(label + ": " + signalingUrl);
         }
-    }
-
-    private void setupControlPanelToggle() {
-        View.OnClickListener toggleListener = v -> {
-            controlsCollapsed = !controlsCollapsed;
-            updateControlPanelVisibility();
-        };
-        binding.controlHeader.setOnClickListener(toggleListener);
-        binding.controlToggleButton.setOnClickListener(toggleListener);
-        updateControlPanelVisibility();
-    }
-
-    private void updateControlPanelVisibility() {
-        if (binding == null) {
-            return;
-        }
-        binding.controlContent.setVisibility(controlsCollapsed ? View.GONE : View.VISIBLE);
-        binding.controlToggleButton.setImageResource(
-                controlsCollapsed ? R.drawable.ic_expand_more : R.drawable.ic_expand_less);
-        binding.controlToggleButton.setContentDescription(getString(
-                controlsCollapsed
-                        ? R.string.camera_stream_control_expand
-                        : R.string.camera_stream_control_collapse));
     }
 
     private void setSelectedCamera(int index, String displayLabel) {
@@ -566,7 +539,6 @@ public class CameraStreamActivity extends AppCompatActivity {
         binding.cameraSelectorLayout.setEnabled(idle && hasCamera);
         binding.cameraSelector.setEnabled(idle && hasCamera);
         binding.connectionProgress.setVisibility(streamingState == StreamingState.CONNECTING ? View.VISIBLE : View.GONE);
-        updateControlPanelVisibility();
     }
 
     private void resetTraveledPath() {
@@ -792,7 +764,6 @@ public class CameraStreamActivity extends AppCompatActivity {
         super.onSaveInstanceState(outState);
         outState.putString(STATE_STREAM_ID, getStreamIdInput());
         outState.putInt(STATE_CAMERA_INDEX, selectedCameraIndex);
-        outState.putBoolean(STATE_CONTROLS_COLLAPSED, controlsCollapsed);
     }
 
     @Override

--- a/android-application/app/src/main/java/com/drone/djiwebrtc/MainActivity.java
+++ b/android-application/app/src/main/java/com/drone/djiwebrtc/MainActivity.java
@@ -18,6 +18,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
@@ -331,6 +332,15 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void initializeSettingsDrawer() {
+        ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(
+                this,
+                binding.drawerLayout,
+                binding.toolbar,
+                R.string.streaming_drawer_open,
+                R.string.streaming_drawer_close);
+        binding.drawerLayout.addDrawerListener(toggle);
+        toggle.syncState();
+
         binding.settingsNavigationView.setNavigationItemSelectedListener(item -> {
             int itemId = item.getItemId();
             if (itemId == R.id.menu_open_mobile_stream) {
@@ -416,6 +426,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void handleStreamingAction() {
+        binding.drawerLayout.closeDrawer(GravityCompat.START);
         if (selectedStreamSource == StreamSource.MOBILE) {
             Intent intent = new Intent(this, CameraStreamActivity.class);
             startActivity(intent);

--- a/android-application/app/src/main/res/layout/activity_camera_stream.xml
+++ b/android-application/app/src/main/res/layout/activity_camera_stream.xml
@@ -24,134 +24,104 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cameraStreamContent"
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/cameraStreamScroll"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="16dp"
+        android:fillViewport="true"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <org.webrtc.SurfaceViewRenderer
-            android:id="@+id/cameraPreview"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:background="@android:color/black"
-            app:layout_constraintDimensionRatio="16:9"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/mapCard"
-            android:layout_width="0dp"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cameraStreamContent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            app:cardUseCompatPadding="true"
-            app:layout_constraintBottom_toTopOf="@id/controlCard"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cameraPreview">
+            android:padding="16dp">
 
-            <LinearLayout
-                android:layout_width="match_parent"
+            <org.webrtc.SurfaceViewRenderer
+                android:id="@+id/cameraPreview"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:background="@android:color/black"
+                app:layout_constraintDimensionRatio="16:9"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/mapCard"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="16dp">
-
-                <TextView
-                    android:id="@+id/pathTitle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/camera_stream_path_title"
-                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1" />
-
-                <TextView
-                    android:id="@+id/pathStatus"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:text="@string/camera_stream_path_waiting"
-                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
-
-                <org.osmdroid.views.MapView
-                    android:id="@+id/pathMap"
-                    android:layout_width="match_parent"
-                    android:layout_height="200dp"
-                    android:layout_marginTop="12dp"
-                    android:clickable="true"
-                    android:focusable="true" />
-
-            </LinearLayout>
-
-        </com.google.android.material.card.MaterialCardView>
-
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/controlCard"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="0dp"
-            android:layout_marginBottom="16dp"
-            app:cardUseCompatPadding="true"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/mapCard">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:animateLayoutChanges="true"
-                android:orientation="vertical">
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                app:cardUseCompatPadding="true"
+                app:layout_constraintBottom_toTopOf="@id/controlCard"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/cameraPreview">
 
                 <LinearLayout
-                    android:id="@+id/controlHeader"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clickable="true"
-                    android:focusable="true"
-                    android:foreground="?attr/selectableItemBackground"
-                    android:gravity="center_vertical"
-                    android:minHeight="48dp"
-                    android:paddingStart="16dp"
-                    android:paddingTop="12dp"
-                    android:paddingEnd="8dp"
-                    android:paddingBottom="12dp">
-
-                    <TextView
-                        android:id="@+id/controlHeaderTitle"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/camera_stream_control_header"
-                        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-                        android:textStyle="bold" />
-
-                    <ImageButton
-                        android:id="@+id/controlToggleButton"
-                        android:layout_width="40dp"
-                        android:layout_height="40dp"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:contentDescription="@string/camera_stream_control_collapse"
-                        android:padding="8dp"
-                        android:tint="?attr/colorOnSurface"
-                        app:srcCompat="@drawable/ic_expand_less" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/controlContent"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:paddingStart="16dp"
-                    android:paddingTop="4dp"
-                    android:paddingEnd="16dp"
-                    android:paddingBottom="16dp">
+                    android:padding="16dp">
+
+                    <TextView
+                        android:id="@+id/pathTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/camera_stream_path_title"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1" />
+
+                    <TextView
+                        android:id="@+id/pathStatus"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/camera_stream_path_waiting"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+                    <org.osmdroid.views.MapView
+                        android:id="@+id/pathMap"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dp"
+                        android:layout_marginTop="12dp"
+                        android:clickable="true"
+                        android:focusable="true" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/controlCard"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:cardUseCompatPadding="true"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/mapCard">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:id="@+id/controlHeaderTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/camera_stream_control_header"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                        android:textStyle="bold" />
 
                     <TextView
                         android:id="@+id/descriptionText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
                         android:text="@string/camera_stream_description"
                         android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
 
@@ -226,6 +196,7 @@
                             android:layout_height="24dp"
                             android:layout_marginStart="12dp"
                             android:visibility="gone" />
+
                     </LinearLayout>
 
                     <TextView
@@ -238,10 +209,10 @@
 
                 </LinearLayout>
 
-            </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
-        </com.google.android.material.card.MaterialCardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android-application/app/src/main/res/layout/activity_main.xml
+++ b/android-application/app/src/main/res/layout/activity_main.xml
@@ -42,115 +42,16 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.card.MaterialCardView
-                android:id="@+id/streamingControlCard"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="12dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginBottom="12dp"
-                app:cardElevation="4dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/videoRenderer">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="16dp">
-
-                    <TextView
-                        android:id="@+id/streamingControlTitle"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/streaming_options_title"
-                        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-                        android:textStyle="bold" />
-
-                    <TextView
-                        android:id="@+id/streamingControlDescription"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:text="@string/streaming_options_description"
-                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
-
-                    <com.google.android.material.button.MaterialButtonToggleGroup
-                        android:id="@+id/streamingSourceToggle"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="12dp"
-                        app:checkedButton="@id/streamSourceDrone"
-                        app:singleSelection="true">
-
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/streamSourceDrone"
-                            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:text="@string/streaming_source_drone" />
-
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/streamSourceMobile"
-                            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:text="@string/streaming_source_mobile" />
-
-                    </com.google.android.material.button.MaterialButtonToggleGroup>
-
-                    <com.google.android.material.switchmaterial.SwitchMaterial
-                        android:id="@+id/includeGpsSwitch"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="12dp"
-                        android:checked="true"
-                        android:text="@string/streaming_option_include_gps"
-                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
-
-                    <com.google.android.material.switchmaterial.SwitchMaterial
-                        android:id="@+id/includeAudioSwitch"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:text="@string/streaming_option_include_audio"
-                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
-
-                    <TextView
-                        android:id="@+id/streamingSummaryText"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="12dp"
-                        android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
-                        tools:text="드론 카메라 • GPS 사용 • 오디오 미사용" />
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/startStreamingButton"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="12dp"
-                        android:text="@string/streaming_action_drone"
-                        app:icon="@drawable/ic_videocam"
-                        app:iconPadding="8dp"
-                        app:iconGravity="textStart" />
-
-                </LinearLayout>
-
-            </com.google.android.material.card.MaterialCardView>
-
             <org.osmdroid.views.MapView
                 android:id="@+id/mapView"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:contentDescription="@string/flight_map_content_description"
+                android:layout_marginTop="12dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/streamingControlCard" />
+                app:layout_constraintTop_toBottomOf="@+id/videoRenderer" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -236,13 +137,140 @@
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/streamingDrawer"
+        android:layout_width="320dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="?attr/colorSurface"
+        android:fitsSystemWindows="true"
+        android:padding="16dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/streaming_drawer_title"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/streaming_drawer_subtitle"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/streamingControlCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                app:cardElevation="2dp"
+                app:cardUseCompatPadding="false">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:id="@+id/streamingControlTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/streaming_options_title"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/streamingControlDescription"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/streaming_options_description"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body2" />
+
+                    <com.google.android.material.button.MaterialButtonToggleGroup
+                        android:id="@+id/streamingSourceToggle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        app:checkedButton="@id/streamSourceDrone"
+                        app:singleSelection="true">
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/streamSourceDrone"
+                            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/streaming_source_drone" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/streamSourceMobile"
+                            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/streaming_source_mobile" />
+
+                    </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/includeGpsSwitch"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:checked="true"
+                        android:text="@string/streaming_option_include_gps"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/includeAudioSwitch"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/streaming_option_include_audio"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+                    <TextView
+                        android:id="@+id/streamingSummaryText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+                        tools:text="드론 카메라 • GPS 사용 • 오디오 미사용" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/startStreamingButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:text="@string/streaming_action_drone"
+                        app:icon="@drawable/ic_videocam"
+                        app:iconGravity="textStart"
+                        app:iconPadding="8dp" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/settingsNavigationView"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="end"
-        android:fitsSystemWindows="true"
         android:background="?attr/colorSurface"
+        android:fitsSystemWindows="true"
         app:menu="@menu/menu_settings_drawer" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/android-application/app/src/main/res/values/strings.xml
+++ b/android-application/app/src/main/res/values/strings.xml
@@ -64,4 +64,8 @@
     <string name="streaming_action_drone">드론 스트림 관리</string>
     <string name="streaming_action_mobile">모바일 스트림 열기</string>
     <string name="streaming_action_drone_message">드론 스트리밍은 자동으로 관리됩니다. 필요한 경우 DJI 연결 상태를 확인하세요.</string>
+    <string name="streaming_drawer_title">스트리밍 옵션</string>
+    <string name="streaming_drawer_subtitle">화면을 가리지 않고도 필요한 제어를 설정할 수 있습니다.</string>
+    <string name="streaming_drawer_open">스트리밍 제어 열기</string>
+    <string name="streaming_drawer_close">스트리밍 제어 닫기</string>
 </resources>


### PR DESCRIPTION
## Summary
- move the main screen streaming options into a dedicated left drawer to declutter the map view
- wire the toolbar hamburger toggle to the new drawer and close it when actions are taken
- simplify the mobile camera streaming screen by keeping controls expanded in a scrollable layout while preserving status indicators

## Testing
- ./gradlew app:assembleDebug *(fails: proxy returns HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f0ffae98832c970e2ee3384e8ac0