### PR TITLE
Handle missing websockets.server attribute

### DIFF
--- a/jetson/websocket_server.py
+++ b/jetson/websocket_server.py
@@ -112,7 +112,13 @@ class DetectionBroadcaster:
     async def start(self) -> None:
         if self._server is not None:
             return
-        base_logger = getattr(websockets.server, "logger", logging.getLogger("websockets.server"))
+        base_logger = logging.getLogger("websockets.server")
+        try:
+            websockets_server_module = importlib.import_module("websockets.server")
+        except ModuleNotFoundError:
+            pass
+        else:
+            base_logger = getattr(websockets_server_module, "logger", base_logger)
         websocket_logger = _StaticRequestSilencingLogger(base_logger)
         self._server = await websockets.serve(
             self._handler,


### PR DESCRIPTION
## Summary
- ensure the WebSocket server logger resolves even when websockets.server is not exposed on the package
- fall back to the default websockets.server logger when the module attribute is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d624036f98832cb705d7676df40a0c