### PR TITLE
Fix WebSocket path normalization in Pion publisher pages

### DIFF
--- a/browser/pion-camera-publisher.html
+++ b/browser/pion-camera-publisher.html
@@ -229,19 +229,14 @@
       setPill('#statePill', 'STARTING', '');
 
       // 1) WS 연결
-      let baseWsUrl;
+      let wsUrlObject;
       try {
-        baseWsUrl = new URL(signaling);
+        wsUrlObject = new URL(signaling);
       } catch (err) {
-        baseWsUrl = new URL(signaling, window.location.href);
+        wsUrlObject = new URL(signaling, window.location.href);
       }
-      const pathSegments = baseWsUrl.pathname.split('/').filter(Boolean);
-      if (pathSegments[pathSegments.length - 1] !== 'ws') {
-        pathSegments.push('ws');
-      }
-      baseWsUrl.pathname = `/${pathSegments.join('/')}`;
-      const baseWs = baseWsUrl.toString();
-      const wsUrlObject = new URL(baseWs);
+      const normalizedPath = wsUrlObject.pathname.replace(/\/+$/, '');
+      wsUrlObject.pathname = normalizedPath ? normalizedPath : '/ws';
       wsUrlObject.searchParams.set('role', 'publisher');
       wsUrlObject.searchParams.set('streamId', streamId);
       ws = new WebSocket(wsUrlObject.toString());

--- a/browser/pion-screen-publisher.html
+++ b/browser/pion-screen-publisher.html
@@ -199,19 +199,14 @@
       setPill('#statePill', 'STARTING', '');
 
       // 1) WS 연결
-      let baseWsUrl;
+      let wsUrlObject;
       try {
-        baseWsUrl = new URL(signaling);
+        wsUrlObject = new URL(signaling);
       } catch (err) {
-        baseWsUrl = new URL(signaling, window.location.href);
+        wsUrlObject = new URL(signaling, window.location.href);
       }
-      const pathSegments = baseWsUrl.pathname.split('/').filter(Boolean);
-      if (pathSegments[pathSegments.length - 1] !== 'ws') {
-        pathSegments.push('ws');
-      }
-      baseWsUrl.pathname = `/${pathSegments.join('/')}`;
-      const baseWs = baseWsUrl.toString();
-      const wsUrlObject = new URL(baseWs);
+      const normalizedPath = wsUrlObject.pathname.replace(/\/+$/, '');
+      wsUrlObject.pathname = normalizedPath ? normalizedPath : '/ws';
       wsUrlObject.searchParams.set('role', 'publisher');
       wsUrlObject.searchParams.set('streamId', streamId);
       ws = new WebSocket(wsUrlObject.toString());


### PR DESCRIPTION
## Summary
- normalize the signaling WebSocket URL instead of forcing a trailing `/ws`
- apply the same normalization to both camera and screen publisher demos so custom endpoints stay intact

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6444edb88832cb984a5674952fd14