### PR TITLE
Fix local preview visibility for camera streams

### DIFF
--- a/android-application/app/src/main/java/com/drone/djiwebrtc/CameraStreamActivity.java
+++ b/android-application/app/src/main/java/com/drone/djiwebrtc/CameraStreamActivity.java
@@ -130,10 +130,7 @@ public class CameraStreamActivity extends AppCompatActivity {
         pionConfigStore = new PionConfigStore(this);
 
         eglBase = EglBase.create();
-        binding.cameraPreview.init(eglBase.getEglBaseContext(), null);
-        binding.cameraPreview.setEnableHardwareScaler(true);
-        binding.cameraPreview.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);
-        binding.cameraPreview.setMirror(false);
+        configurePreviewSurface();
 
         initialiseCameraEnumerator();
         initialiseStreamIdField(savedInstanceState);
@@ -152,6 +149,17 @@ public class CameraStreamActivity extends AppCompatActivity {
             updateStatus(getString(R.string.camera_stream_status_idle));
         }
         updateUiState();
+    }
+
+    private void configurePreviewSurface() {
+        binding.cameraPreview.setZOrderOnTop(true);
+        binding.cameraPreview.setZOrderMediaOverlay(true);
+        binding.cameraPreview.setEnableHardwareScaler(true);
+        binding.cameraPreview.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);
+        binding.cameraPreview.setMirror(false);
+        binding.cameraPreview.setKeepScreenOn(true);
+        binding.cameraPreview.init(eglBase.getEglBaseContext(), null);
+        binding.cameraPreview.setVisibility(View.VISIBLE);
     }
 
     private void initialiseCameraEnumerator() {

--- a/android-application/app/src/main/java/com/drone/djiwebrtc/webrtc/DroneVideoPreview.java
+++ b/android-application/app/src/main/java/com/drone/djiwebrtc/webrtc/DroneVideoPreview.java
@@ -55,6 +55,8 @@ public class DroneVideoPreview {
                 .createPeerConnectionFactory();
 
         surfaceViewRenderer.init(eglBase.getEglBaseContext(), null);
+        surfaceViewRenderer.setZOrderOnTop(true);
+        surfaceViewRenderer.setZOrderMediaOverlay(true);
         surfaceViewRenderer.setEnableHardwareScaler(true);
         surfaceViewRenderer.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);
         surfaceViewRenderer.setMirror(false);


### PR DESCRIPTION
## Summary
- ensure the mobile camera preview surface is fully configured before streaming so frames render on screen
- align the drone preview surface setup so it renders above overlapping views

## Testing
- not run (Gradle lint command could not complete in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d64b1f4508832cb7d0f043fadf2530