### PR TITLE
Fix HTTP handshake compatibility with websockets 12

### DIFF
--- a/jetson/websocket_server.py
+++ b/jetson/websocket_server.py
@@ -650,18 +650,13 @@ class DetectionBroadcaster:
                     reason_phrase = ""
 
             try:
-                response = self._create_websockets_response(
+                return self._create_websockets_response(
                     status_code, headers_value, body, reason_phrase
                 )
             except Exception:
                 logging.debug(
                     "Falling back to tuple HTTP response for websockets", exc_info=True
                 )
-            else:
-                status_value = getattr(response, "status_code", status_code)
-                headers_value = getattr(response, "headers", header_items)
-                body_value = getattr(response, "body", body)
-                return status_value, headers_value, body_value
 
         return status_code, header_items, body
 


### PR DESCRIPTION
## Summary
- ensure the HTTP fallback in `DetectionBroadcaster` returns a proper websockets Response when available
- prevent handshake assertions caused by returning tuple responses on newer websockets releases

## Testing
- python -m compileall jetson/websocket_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d64d9598d8832ca678a7317819baa9