### PR TITLE
Ensure camera preview sinks attach when capture starts

### DIFF
--- a/android-application/app/src/main/java/com/drone/djiwebrtc/core/WebRTCClient.java
+++ b/android-application/app/src/main/java/com/drone/djiwebrtc/core/WebRTCClient.java
@@ -187,6 +187,10 @@ public class WebRTCClient {
 
         videoTrackFromCamera = getFactory(context).createVideoTrack(options.getVideoSourceId(), videoSource);
         videoTrackFromCamera.setEnabled(true);
+
+        for (VideoSink sink : localVideoSinks) {
+            videoTrackFromCamera.addSink(sink);
+        }
     }
 
     private void initializePeerConnection() {
@@ -277,19 +281,23 @@ public class WebRTCClient {
     }
 
     public void addVideoSink(VideoSink sink) {
-        if (sink == null || videoTrackFromCamera == null) {
+        if (sink == null) {
             return;
         }
-        videoTrackFromCamera.addSink(sink);
         localVideoSinks.add(sink);
+        if (videoTrackFromCamera != null) {
+            videoTrackFromCamera.addSink(sink);
+        }
     }
 
     public void removeVideoSink(VideoSink sink) {
-        if (sink == null || videoTrackFromCamera == null) {
+        if (sink == null) {
             return;
         }
-        videoTrackFromCamera.removeSink(sink);
         localVideoSinks.remove(sink);
+        if (videoTrackFromCamera != null) {
+            videoTrackFromCamera.removeSink(sink);
+        }
     }
 
     public synchronized void dispose() {


### PR DESCRIPTION
## Summary
- remove the DJI drone capturer lifecycle callbacks that were unrelated to the mobile camera streaming issue
- keep local video sinks attached once the mobile camera track is created so the in-app preview receives frames

## Testing
- `./gradlew --console=plain app:lintDebug` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d64e696a54832cb4b93a32396e9ffb