### PR TITLE
Disable H264 high profile for WebRTC

### DIFF
--- a/android-application/app/src/main/java/com/drone/djiwebrtc/core/WebRTCClient.java
+++ b/android-application/app/src/main/java/com/drone/djiwebrtc/core/WebRTCClient.java
@@ -83,7 +83,7 @@ public class WebRTCClient {
         // Initialize the PeerConnectionFactory
         PeerConnectionFactory.InitializationOptions options = PeerConnectionFactory.InitializationOptions.builder(context)
                 .setEnableInternalTracer(true)
-                .setFieldTrials("WebRTC-H264HighProfile/Enabled/")
+                .setFieldTrials("WebRTC-H264HighProfile/Disabled/")
                 .createInitializationOptions();
         PeerConnectionFactory.initialize(options);
 
@@ -91,7 +91,7 @@ public class WebRTCClient {
         factory = PeerConnectionFactory
                 .builder()
                 .setVideoDecoderFactory(new DefaultVideoDecoderFactory(rootEglBase.getEglBaseContext()))
-                .setVideoEncoderFactory(new DefaultVideoEncoderFactory(rootEglBase.getEglBaseContext(), true, true))
+                .setVideoEncoderFactory(new DefaultVideoEncoderFactory(rootEglBase.getEglBaseContext(), true, false))
                 .setOptions(new PeerConnectionFactory.Options()).createPeerConnectionFactory();
     }
 


### PR DESCRIPTION
## Summary
- disable WebRTC H264 high profile field trial to keep encoder output baseline compatible
- turn off high profile support in the default video encoder factory to avoid generating SPS values Pion cannot parse

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6690e7ad8832c96a472a45c593a41