### PR TITLE
Fix camera preview not visible during mobile streaming

### DIFF
--- a/android-application/app/src/main/java/com/drone/djiwebrtc/CameraStreamActivity.java
+++ b/android-application/app/src/main/java/com/drone/djiwebrtc/CameraStreamActivity.java
@@ -152,14 +152,16 @@ public class CameraStreamActivity extends AppCompatActivity {
     }
 
     private void configurePreviewSurface() {
-        binding.cameraPreview.setZOrderOnTop(false);
-        binding.cameraPreview.setZOrderMediaOverlay(false);
+        binding.cameraPreview.init(eglBase.getEglBaseContext(), null);
+        binding.cameraPreview.setZOrderOnTop(true);
+        binding.cameraPreview.setZOrderMediaOverlay(true);
         binding.cameraPreview.setEnableHardwareScaler(true);
         binding.cameraPreview.setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FILL);
         binding.cameraPreview.setMirror(false);
         binding.cameraPreview.setKeepScreenOn(true);
-        binding.cameraPreview.init(eglBase.getEglBaseContext(), null);
         binding.cameraPreview.setVisibility(View.VISIBLE);
+        binding.cameraPreview.bringToFront();
+        binding.cameraPreview.clearImage();
     }
 
     private void initialiseCameraEnumerator() {
@@ -519,6 +521,10 @@ public class CameraStreamActivity extends AppCompatActivity {
         stopLocationUpdates();
         lastTelemetrySentRealtime = 0L;
         lastKnownLocation = null;
+
+        if (binding != null) {
+            binding.cameraPreview.clearImage();
+        }
 
         if (!availableCameras.isEmpty()) {
             if (TextUtils.isEmpty(statusMessage)) {


### PR DESCRIPTION
## Summary
- ensure the mobile camera preview renderer is initialised on top of surrounding views so captured frames are visible while streaming
- clear the preview surface whenever streaming stops to avoid leaving stale black frames before the next session

## Testing
- ./gradlew lint --console=plain --no-daemon *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d66a828418832caef78c43f4bfd878