### PR TITLE
Fix AVError import compatibility

### DIFF
--- a/jetson/webrtc_receiver.py
+++ b/jetson/webrtc_receiver.py
@@ -12,8 +12,13 @@ from aiortc import RTCPeerConnection, RTCSessionDescription
 from aiortc.sdp import candidate_from_sdp
 from aiortc.contrib.signaling import BYE
 from aiortc.mediastreams import MediaStreamError
+import av
 from av import VideoFrame
-from av import AVError
+
+if hasattr(av, "AVError"):
+    AVError = av.AVError
+else:  # pragma: no cover - compatibility shim for newer PyAV
+    from av.error import AVError  # type: ignore[attr-defined]
 import websockets
 from websockets.exceptions import ConnectionClosed
 


### PR DESCRIPTION
## Summary
- adjust AVError import to work with newer PyAV releases where it moved to av.error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66db6578c832c940fb0cf315b87f2