### PR TITLE
Integrate Twelve Labs analysis caching with dashboard

### DIFF
--- a/browser/dashboard.html
+++ b/browser/dashboard.html
@@ -370,6 +370,47 @@
       color: #e2e8f0;
     }
 
+    .analysis-result-block {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding-top: 0.5rem;
+      border-top: 1px solid rgba(148, 163, 184, 0.18);
+    }
+
+    .analysis-result-block h4 {
+      margin: 0;
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: #cbd5f5;
+    }
+
+    .analysis-output-body {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      background: rgba(15, 23, 42, 0.55);
+      padding: 0.75rem;
+      border-radius: 8px;
+      border: 1px solid rgba(148, 163, 184, 0.15);
+      color: #e2e8f0;
+      font-size: 0.9rem;
+      line-height: 1.45;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .analysis-output-body pre {
+      margin: 0;
+      padding: 0.5rem;
+      border-radius: 6px;
+      background: rgba(15, 23, 42, 0.75);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      overflow: auto;
+      font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace;
+      font-size: 0.85rem;
+    }
+
     .analysis-meta-grid {
       display: grid;
       grid-template-columns: minmax(120px, 0.4fr) minmax(180px, 1fr);
@@ -1052,7 +1093,7 @@
               <p class="analysis-meta" id="analysisRecordingMeta">Choose a recording on the left to see its details.</p>
             </div>
             <div class="analysis-output" id="analysisDetails">
-              <p>The analysis workspace will display AI insights once the integration details are configured.</p>
+              <p>Select a recording and choose “Analyze” to run the Twelve Labs summary when the server integration is configured.</p>
             </div>
           </section>
         </div>

--- a/jetson/requirements.txt
+++ b/jetson/requirements.txt
@@ -3,3 +3,4 @@ numpy
 opencv-python
 ultralytics
 websockets
+requests

--- a/jetson/twelvelabs_service.py
+++ b/jetson/twelvelabs_service.py
@@ -1,0 +1,298 @@
+"""Utilities to embed and analyse recordings with the Twelve Labs API."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from scripts.twelvelabs_client import (
+    DEFAULT_ANALYSIS_PATH,
+    DEFAULT_BASE_URL,
+    DEFAULT_EMBEDDING_TASK_PATH,
+    TwelveLabsClient,
+    TwelveLabsError,
+    _extract_video_id,
+)
+
+__all__ = [
+    "AnalysisServiceError",
+    "RecordingNotFoundError",
+    "TwelveLabsAnalysisService",
+]
+
+
+class AnalysisServiceError(RuntimeError):
+    """Base class for analysis orchestration errors."""
+
+
+class RecordingNotFoundError(AnalysisServiceError):
+    """Raised when the requested recording could not be located on disk."""
+
+
+def _clone_json(data: Any) -> Any:
+    """Return a deep copy of ``data`` by round-tripping through JSON."""
+
+    return json.loads(json.dumps(data))
+
+
+def _utc_iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _serialise_signature(stat_result) -> Dict[str, Any]:
+    modified = datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc)
+    return {
+        "size": stat_result.st_size,
+        "modified": modified.isoformat().replace("+00:00", "Z"),
+    }
+
+
+def _ensure_directory(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass
+class AnalysisResult:
+    record: Dict[str, Any]
+    cached: bool
+
+
+class TwelveLabsAnalysisService:
+    """Create embeddings and cached analysis results for stored recordings."""
+
+    def __init__(
+        self,
+        *,
+        client: TwelveLabsClient,
+        model_name: str,
+        recordings_dir: Path,
+        storage_path: Path,
+        default_prompt: str,
+        poll_interval: int = 10,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        video_embedding_scope: Optional[Iterable[str]] = None,
+        gzip_upload: bool = True,
+    ) -> None:
+        self._client = client
+        self._model_name = model_name
+        self._recordings_dir = Path(recordings_dir)
+        self._storage_path = Path(storage_path)
+        self._default_prompt = default_prompt
+        self._poll_interval = max(1, int(poll_interval))
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        self._scopes = [scope for scope in video_embedding_scope or [] if scope]
+        self._gzip_upload = gzip_upload
+        self._lock = threading.Lock()
+        self._records: Dict[str, Dict[str, Any]] = {}
+        self._load_cache()
+
+    @staticmethod
+    def default_client(api_key: str) -> TwelveLabsClient:
+        """Return a Twelve Labs client configured with default endpoints."""
+
+        return TwelveLabsClient(
+            api_key=api_key,
+            base_url=DEFAULT_BASE_URL,
+            embedding_path=DEFAULT_EMBEDDING_TASK_PATH,
+            analysis_path=DEFAULT_ANALYSIS_PATH,
+        )
+
+    def _build_key(self, stream_id: str, file_name: str) -> str:
+        return f"{stream_id}/{file_name}"
+
+    def _load_cache(self) -> None:
+        if not self._storage_path.exists():
+            return
+        try:
+            payload = json.loads(self._storage_path.read_text(encoding="utf-8"))
+        except Exception:
+            return
+        records = payload.get("records") if isinstance(payload, dict) else None
+        if isinstance(records, dict):
+            self._records = {
+                key: value
+                for key, value in records.items()
+                if isinstance(key, str) and isinstance(value, dict)
+            }
+
+    def _save_cache(self) -> None:
+        _ensure_directory(self._storage_path)
+        snapshot = {"records": self._records}
+        temp_dir = self._storage_path.parent
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=str(temp_dir),
+            delete=False,
+        ) as handle:
+            json.dump(snapshot, handle, indent=2, ensure_ascii=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temp_path = Path(handle.name)
+        temp_path.replace(self._storage_path)
+
+    def _resolve_recording_path(self, stream_id: str, file_name: str) -> Path:
+        if not stream_id:
+            raise RecordingNotFoundError("streamId is required")
+        if not file_name:
+            raise RecordingNotFoundError("fileName is required")
+        candidate = (self._recordings_dir / stream_id / file_name).resolve()
+        try:
+            candidate.relative_to(self._recordings_dir)
+        except ValueError as exc:  # pragma: no cover - safety check
+            raise RecordingNotFoundError("Recording path escapes recordings directory") from exc
+        if not candidate.exists() or not candidate.is_file():
+            raise RecordingNotFoundError(
+                f"Recording {stream_id}/{file_name} was not found at {candidate}"
+            )
+        return candidate
+
+    def _signature_matches(self, existing: Dict[str, Any], signature: Dict[str, Any]) -> bool:
+        source = existing.get("source") if isinstance(existing, dict) else {}
+        stored = source.get("signature") if isinstance(source, dict) else None
+        return stored == signature
+
+    def get_cached_record(self, stream_id: str, file_name: str) -> Optional[Dict[str, Any]]:
+        key = self._build_key(stream_id, file_name)
+        with self._lock:
+            record = self._records.get(key)
+            if record is None:
+                return None
+            return _clone_json(record)
+
+    def list_cached_records(self) -> list[Dict[str, Any]]:
+        with self._lock:
+            records = [_clone_json(record) for record in self._records.values()]
+        records.sort(
+            key=lambda item: item.get("updatedAt") or item.get("source", {}).get("modified") or "",
+            reverse=True,
+        )
+        return records
+
+    def ensure_analysis(
+        self,
+        *,
+        stream_id: str,
+        file_name: str,
+        prompt: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> AnalysisResult:
+        recording_path = self._resolve_recording_path(stream_id, file_name)
+        stat_result = recording_path.stat()
+        signature = _serialise_signature(stat_result)
+        key = self._build_key(stream_id, file_name)
+
+        with self._lock:
+            existing = self._records.get(key)
+            if existing and existing.get("analysis") and self._signature_matches(existing, signature):
+                return AnalysisResult(record=_clone_json(existing), cached=True)
+
+        prompt_value = (prompt or self._default_prompt).strip()
+        temperature_value = self._temperature if temperature is None else temperature
+        max_tokens_value = self._max_tokens if max_tokens is None else max_tokens
+
+        embedding_kwargs: Dict[str, Any] = {
+            "model_name": self._model_name,
+            "video_embedding_scope": self._scopes or None,
+            "gzip_upload": self._gzip_upload,
+        }
+
+        with open(recording_path, "rb") as handle:
+            embedding_response = self._client.create_embedding(
+                video_file=handle,
+                video_file_name=file_name,
+                **embedding_kwargs,
+            )
+
+        task_id = (
+            embedding_response.get("task_id")
+            or embedding_response.get("id")
+            or embedding_response.get("_id")
+        )
+        if not task_id:
+            raise AnalysisServiceError(
+                "Embedding response did not include a task identifier"
+            )
+        status_url = embedding_response.get("status_url") or embedding_response.get("href")
+        if not isinstance(status_url, str) or not status_url:
+            status_url = f"{self._client.embedding_path.rstrip('/')}/{task_id}/status"
+
+        embedding_status = self._client.wait_for_task(
+            status_url=status_url,
+            poll_interval=self._poll_interval,
+        )
+
+        video_id = _extract_video_id(embedding_status)
+        if not video_id:
+            raise AnalysisServiceError("Unable to determine Twelve Labs video_id from embedding status")
+
+        analysis_payload: Dict[str, Any] = {
+            "video_id": video_id,
+            "prompt": prompt_value,
+            "stream": False,
+        }
+        if temperature_value is not None:
+            analysis_payload["temperature"] = temperature_value
+        if max_tokens_value is not None:
+            analysis_payload["max_tokens"] = max_tokens_value
+
+        analysis_response = self._client.request_analysis(
+            video_id=video_id,
+            prompt=prompt_value,
+            temperature=temperature_value,
+            stream=False,
+            max_tokens=max_tokens_value,
+        )
+
+        record = {
+            "streamId": stream_id,
+            "fileName": file_name,
+            "source": {
+                "path": str(recording_path),
+                "signature": signature,
+            },
+            "prompt": prompt_value,
+            "temperature": temperature_value,
+            "maxTokens": max_tokens_value,
+            "videoEmbeddingScope": list(self._scopes) if self._scopes else None,
+            "pollInterval": self._poll_interval,
+            "videoId": video_id,
+            "updatedAt": _utc_iso_now(),
+            "embedding": {
+                "taskId": task_id,
+                "statusUrl": status_url,
+                "response": embedding_response,
+                "status": embedding_status,
+                "request": {
+                    "modelName": self._model_name,
+                    "gzipUpload": self._gzip_upload,
+                },
+            },
+            "analysis": {
+                "request": analysis_payload,
+                "response": analysis_response,
+            },
+        }
+
+        with self._lock:
+            self._records[key] = record
+            self._save_cache()
+
+        return AnalysisResult(record=_clone_json(record), cached=False)
+
+
+__all__ += [
+    "DEFAULT_BASE_URL",
+    "DEFAULT_EMBEDDING_TASK_PATH",
+    "DEFAULT_ANALYSIS_PATH",
+    "TwelveLabsError",
+]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Helper utilities for interacting with the Twelve Labs APIs."""
+
+__all__ = [
+    "twelvelabs_client",
+]

--- a/scripts/twelvelabs_client.py
+++ b/scripts/twelvelabs_client.py
@@ -1,0 +1,481 @@
+"""Command line client for embedding and analyzing videos with the Twelve Labs API.
+
+The script performs the following steps:
+1. Upload a video (or provide a public URL) to create an embedding task.
+2. Poll the embedding task until it is completed and extract the resulting video ID.
+3. Trigger an open-ended analysis request with a natural language prompt and print the
+   response JSON to stdout.
+
+Usage example::
+
+    python scripts/twelvelabs_client.py \
+        --api-key "$TWELVE_LABS_API_KEY" \
+        --model-name "Marengo-retrieval-2.7" \
+        --video-file /path/to/video.mp4 \
+        --prompt "Summarize the main events" \
+        --temperature 0.2
+
+The script intentionally keeps the payload shape close to the public
+API specification. The default embedding path points at the v1.3 task
+creation endpoint documented at
+https://docs.twelvelabs.io/v1.3/api-reference/video-embeddings/create-video-embedding-task
+and the analysis request follows the v1.3 open-ended analysis API at
+https://docs.twelvelabs.io/api-reference/analyze-videos. Both paths can
+be overridden with ``--embedding-path`` and ``--analysis-path`` when
+Twelve Labs publishes an updated revision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, BinaryIO
+
+import requests
+
+
+DEFAULT_BASE_URL = "https://api.twelvelabs.io"
+DEFAULT_EMBEDDING_TASK_PATH = "/v1.3/embed/tasks"
+DEFAULT_ANALYSIS_PATH = "/v1.3/analyze"
+
+
+class TwelveLabsError(RuntimeError):
+    """Raised when an API call fails."""
+
+
+@dataclass
+class TwelveLabsClient:
+    """Small helper around the Twelve Labs REST API."""
+
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    timeout: int = 30
+    embedding_path: str = DEFAULT_EMBEDDING_TASK_PATH
+    analysis_path: str = DEFAULT_ANALYSIS_PATH
+
+    def __post_init__(self) -> None:
+        self.session = requests.Session()
+        self.session.headers.update({
+            "accept": "application/json",
+            "x-api-key": self.api_key,
+        })
+
+    def _post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = path if path.startswith("http") else f"{self.base_url}{path}"
+        response = self.session.post(
+            url,
+            json=payload,
+            timeout=self.timeout,
+        )
+        self._raise_for_status(response)
+        return response.json()
+
+    def _get(self, path: str) -> Dict[str, Any]:
+        url = path if path.startswith("http") else f"{self.base_url}{path}"
+        response = self.session.get(
+            url,
+            timeout=self.timeout,
+        )
+        self._raise_for_status(response)
+        return response.json()
+
+    @staticmethod
+    def _raise_for_status(response: requests.Response) -> None:
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:  # pragma: no cover - defensive branch
+            message = exc.response.text if exc.response is not None else str(exc)
+            raise TwelveLabsError(message) from exc
+
+    def create_embedding(
+        self,
+        *,
+        model_name: str,
+        video_file: Optional[BinaryIO] = None,
+        video_file_name: Optional[str] = None,
+        video_url: Optional[str] = None,
+        video_start_offset_sec: Optional[float] = None,
+        video_end_offset_sec: Optional[float] = None,
+        video_clip_length: Optional[float] = None,
+        video_embedding_scope: Optional[Iterable[str]] = None,
+        gzip_upload: bool = True,
+    ) -> Dict[str, Any]:
+        """Create a video embedding task using either a local file or a URL."""
+
+        if not video_file and not video_url:
+            raise ValueError("Either video_file or video_url must be supplied for embeddings")
+
+        url = (
+            self.embedding_path
+            if self.embedding_path.startswith("http")
+            else f"{self.base_url}{self.embedding_path}"
+        )
+
+        form_data: Dict[str, Any] = {"model_name": model_name}
+        if video_url:
+            form_data["video_url"] = video_url
+        if video_start_offset_sec is not None:
+            form_data["video_start_offset_sec"] = str(video_start_offset_sec)
+        if video_end_offset_sec is not None:
+            form_data["video_end_offset_sec"] = str(video_end_offset_sec)
+        if video_clip_length is not None:
+            form_data["video_clip_length"] = str(video_clip_length)
+        if video_embedding_scope:
+            scopes = [scope for scope in video_embedding_scope if scope]
+            if not scopes:
+                raise ValueError("video_embedding_scope must contain at least one value when provided")
+            primary, *extra = scopes
+            form_data["video_embedding_scope"] = primary
+            if extra:
+                form_data["_extra_scopes"] = [("video_embedding_scope", scope) for scope in extra]
+
+        files = None
+        gzip_handle: Optional[BinaryIO] = None
+        if video_file and not video_url:
+            filename = video_file_name or getattr(video_file, "name", "video.mp4") or "video.mp4"
+            upload_handle: BinaryIO
+            upload_headers: Optional[Dict[str, str]] = None
+            if gzip_upload:
+                gzip_handle = _gzip_file(video_file)
+                upload_handle = gzip_handle
+                upload_headers = {"Content-Encoding": "gzip"}
+            else:
+                if hasattr(video_file, "seek"):
+                    video_file.seek(0)
+                upload_handle = video_file
+            file_tuple = (
+                os.path.basename(filename),
+                upload_handle,
+                "application/octet-stream",
+            )
+            if upload_headers:
+                file_tuple = file_tuple + (upload_headers,)
+            files = {
+                "video_file": file_tuple,
+            }
+
+        data_items = [(key, value) for key, value in form_data.items() if key != "_extra_scopes"]
+        for scope_entry in form_data.get("_extra_scopes", []):
+            data_items.append(scope_entry)
+
+        try:
+            response = self.session.post(
+                url,
+                data=data_items,
+                files=files,
+                timeout=self.timeout,
+            )
+            self._raise_for_status(response)
+            return response.json()
+        finally:
+            if gzip_handle is not None:
+                gzip_handle.close()
+
+    def request_analysis(
+        self,
+        *,
+        video_id: str,
+        prompt: str,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+        response_format: Optional[Dict[str, Any]] = None,
+        max_tokens: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Trigger an open-ended analysis request for a stored video."""
+
+        payload: Dict[str, Any] = {
+            "video_id": video_id,
+            "prompt": prompt,
+            "stream": stream,
+        }
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if response_format is not None:
+            payload["response_format"] = response_format
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+
+        if not stream:
+            return self._post(self.analysis_path, payload)
+
+        url = (
+            self.analysis_path
+            if self.analysis_path.startswith("http")
+            else f"{self.base_url}{self.analysis_path}"
+        )
+        response = self.session.post(
+            url,
+            json=payload,
+            timeout=self.timeout,
+            stream=True,
+        )
+        try:
+            self._raise_for_status(response)
+            chunks = []
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                try:
+                    decoded = line.decode("utf-8")
+                except AttributeError:
+                    decoded = line
+                chunks.append(json.loads(decoded))
+            return {"stream": chunks}
+        finally:
+            response.close()
+
+    def wait_for_task(
+        self,
+        *,
+        status_url: str,
+        poll_interval: int = 10,
+    ) -> Dict[str, Any]:
+        """Poll a task endpoint until it completes or fails."""
+
+        if not status_url:
+            raise ValueError("status_url is required to poll task status")
+
+        while True:
+            data = self._get(status_url)
+            task_info = data.get("task", {}) if isinstance(data, dict) else {}
+            status = (
+                (data.get("status") if isinstance(data, dict) else None)
+                or task_info.get("status")
+                or task_info.get("state")
+                or (data.get("state") if isinstance(data, dict) else None)
+                or task_info.get("task_status")
+            )
+            if status in {"completed", "succeeded", "ready", "finished"}:
+                return data
+            if status in {"failed", "error", "cancelled", "canceled"}:
+                raise TwelveLabsError(json.dumps(data))
+            time.sleep(poll_interval)
+
+
+def _coerce_scopes(raw: Optional[Iterable[str]]) -> Optional[Iterable[str]]:
+    if raw is None:
+        return None
+    scopes = [scope for scope in raw if scope]
+    return scopes or None
+
+
+def _gzip_file(source: BinaryIO, *, chunk_size: int = 1024 * 1024) -> BinaryIO:
+    """Return a temporary file-like object containing gzipped contents of *source*."""
+
+    if hasattr(source, "seek"):
+        source.seek(0)
+    spool = tempfile.SpooledTemporaryFile(max_size=8 * 1024 * 1024)
+    with gzip.GzipFile(fileobj=spool, mode="wb") as gz_stream:
+        while True:
+            chunk = source.read(chunk_size)
+            if not chunk:
+                break
+            gz_stream.write(chunk)
+    spool.seek(0)
+    if hasattr(source, "seek"):
+        source.seek(0)
+    return spool
+
+
+def _load_response_format(raw: Optional[str]) -> Optional[Dict[str, Any]]:
+    if raw is None:
+        return None
+    candidate = raw.strip()
+    if not candidate:
+        return None
+    if os.path.exists(candidate):
+        with open(candidate, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    else:
+        data = json.loads(candidate)
+    if not isinstance(data, dict):
+        raise ValueError("response_format must be a JSON object")
+    return data
+
+
+def _extract_video_id(payload: Dict[str, Any]) -> Optional[str]:
+    """Try to locate a Twelve Labs video identifier in the payload."""
+
+    if not isinstance(payload, dict):
+        return None
+
+    candidates = [
+        payload.get("video_id"),
+        payload.get("id"),
+        payload.get("_id"),
+    ]
+
+    for key in ("task", "data", "result", "embedding"):
+        nested = payload.get(key)
+        if isinstance(nested, dict):
+            candidates.extend(
+                [
+                    nested.get("video_id"),
+                    nested.get("id"),
+                    nested.get("_id"),
+                ]
+            )
+            videos = nested.get("videos")
+            if isinstance(videos, list):
+                for item in videos:
+                    if isinstance(item, dict):
+                        candidates.append(item.get("video_id"))
+        elif isinstance(nested, list):
+            for item in nested:
+                if isinstance(item, dict):
+                    candidates.append(item.get("video_id"))
+
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def run_pipeline(args: argparse.Namespace) -> None:
+    client = TwelveLabsClient(
+        api_key=args.api_key,
+        base_url=args.base_url,
+        timeout=args.timeout,
+        embedding_path=args.embedding_path,
+        analysis_path=args.analysis_path,
+    )
+
+    if not args.video_file and not args.video_url:
+        raise SystemExit("Provide either --video-file or --video-url to create embeddings")
+
+    print("[1/3] Creating embeddings task...", file=sys.stderr)
+    embedding_kwargs = {
+        "model_name": args.model_name,
+        "video_url": args.video_url,
+        "video_start_offset_sec": args.video_start_offset,
+        "video_end_offset_sec": args.video_end_offset,
+        "video_clip_length": args.video_clip_length,
+        "video_embedding_scope": _coerce_scopes(args.video_embedding_scope),
+        "gzip_upload": not args.disable_upload_gzip,
+    }
+
+    video_file_handle: Optional[BinaryIO] = None
+    if args.video_file and not args.video_url:
+        video_file_handle = open(args.video_file, "rb")
+        embedding_kwargs.update(
+            {
+                "video_file": video_file_handle,
+                "video_file_name": args.video_file,
+            }
+        )
+
+    try:
+        embedding_response = client.create_embedding(**embedding_kwargs)
+    finally:
+        if video_file_handle is not None:
+            video_file_handle.close()
+
+    embedding_task_id = (
+        embedding_response.get("task_id")
+        or embedding_response.get("id")
+        or embedding_response.get("_id")
+    )
+    if not embedding_task_id:
+        raise SystemExit("Embedding response does not contain a task identifier.")
+
+    embedding_status_path = embedding_response.get("status_url") or embedding_response.get("href")
+    if not isinstance(embedding_status_path, str) or not embedding_status_path:
+        embedding_status_path = f"{client.embedding_path.rstrip('/')}/{embedding_task_id}/status"
+
+    print("[2/3] Waiting for embeddings to complete...", file=sys.stderr)
+    embedding_status = client.wait_for_task(
+        status_url=embedding_status_path,
+        poll_interval=args.poll_interval,
+    )
+
+    analysis_video_id = args.analysis_video_id or _extract_video_id(embedding_status)
+    if not analysis_video_id:
+        raise SystemExit(
+            "Could not determine the Twelve Labs video_id from the embedding status. "
+            "Pass --analysis-video-id explicitly to continue."
+        )
+
+    try:
+        response_format = _load_response_format(args.response_format)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise SystemExit(f"Failed to parse --response-format: {exc}") from exc
+
+    print("[3/3] Requesting analysis...", file=sys.stderr)
+    analysis_result = client.request_analysis(
+        video_id=analysis_video_id,
+        prompt=args.prompt,
+        temperature=args.temperature,
+        stream=args.analysis_stream,
+        response_format=response_format,
+        max_tokens=args.max_tokens,
+    )
+
+    print(json.dumps(
+        {
+            "embedding": embedding_status,
+            "analysis": analysis_result,
+        },
+        indent=2,
+        ensure_ascii=False,
+    ))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Embed uploaded videos and analyze them with Twelve Labs")
+    parser.add_argument("--api-key", required=True, help="Twelve Labs API key")
+    parser.add_argument("--model-name", required=True, help="Embedding model to use (e.g. Marengo-retrieval-2.7)")
+    parser.add_argument("--video-file", help="Path to a local video file for embedding")
+    parser.add_argument("--video-url", help="Public URL pointing directly to the video file")
+    parser.add_argument("--video-start-offset", type=float, help="Start offset in seconds from the beginning of the video")
+    parser.add_argument("--video-end-offset", type=float, help="End offset in seconds from the beginning of the video")
+    parser.add_argument("--video-clip-length", type=float, help="Clip length in seconds for segment embeddings")
+    parser.add_argument(
+        "--video-embedding-scope",
+        action="append",
+        help="Embedding scope values (clip, video). Repeat the flag to request multiple scopes",
+    )
+    parser.add_argument("--prompt", required=True, help="Natural language prompt for the analysis")
+    parser.add_argument(
+        "--analysis-video-id",
+        help="Override the video_id used for analysis if it cannot be derived automatically",
+    )
+    parser.add_argument("--temperature", type=float, help="Sampling temperature for text generation (0-1)")
+    parser.add_argument(
+        "--analysis-stream",
+        action="store_true",
+        help="Enable NDJSON streaming responses from the analysis endpoint",
+    )
+    parser.add_argument("--max-tokens", type=int, help="Maximum number of tokens to generate")
+    parser.add_argument(
+        "--response-format",
+        help="JSON object or path to JSON file describing the desired response_format",
+    )
+    parser.add_argument(
+        "--disable-upload-gzip",
+        action="store_true",
+        help="Send the raw video bytes instead of gzip-compressing them for uploads",
+    )
+    parser.add_argument("--poll-interval", type=int, default=10, help="Seconds between task status polls")
+    parser.add_argument("--timeout", type=int, default=30, help="HTTP request timeout in seconds")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="Override the Twelve Labs API base URL")
+    parser.add_argument(
+        "--embedding-path",
+        default=DEFAULT_EMBEDDING_TASK_PATH,
+        help="API path used to create and poll embedding tasks (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--analysis-path",
+        default=DEFAULT_ANALYSIS_PATH,
+        help="API path used to create and poll analysis tasks (default: %(default)s)",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    run_pipeline(build_parser().parse_args())


### PR DESCRIPTION
## Summary
- add a Twelve Labs analysis service that uploads recordings, waits for embeddings, and stores cached responses for reuse
- expose a `/analysis` endpoint on the detection broadcaster with environment-based configuration and error handling
- update the dashboard UI to call the new endpoint, reuse cached summaries, and surface formatted Twelve Labs output
- document the integration workflow and required environment variables, and add the requests dependency for the Jetson server

## Testing
- python -m compileall scripts/twelvelabs_client.py jetson/twelvelabs_service.py jetson/websocket_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d72e80ba48832cb08c1539493ce4a6