### PR TITLE
Handle Twelve Labs connection resets and lazy exports

### DIFF
--- a/jetson/__init__.py
+++ b/jetson/__init__.py
@@ -1,12 +1,16 @@
 """Runtime helpers for running the WebRTC/YOLO stack on Jetson devices."""
 
-from .twelvelabs_client import TwelveLabsClient, TwelveLabsError
-from .twelvelabs_service import (
-    AnalysisResult,
-    AnalysisServiceError,
-    RecordingNotFoundError,
-    TwelveLabsAnalysisService,
-)
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - import-time type hints only
+    from .twelvelabs_client import TwelveLabsClient, TwelveLabsError
+    from .twelvelabs_service import (
+        AnalysisResult,
+        AnalysisServiceError,
+        RecordingNotFoundError,
+        TwelveLabsAnalysisService,
+    )
 
 __all__ = [
     "AnalysisResult",
@@ -16,3 +20,23 @@ __all__ = [
     "TwelveLabsClient",
     "TwelveLabsError",
 ]
+
+_EXPORTS = {
+    "TwelveLabsClient": (".twelvelabs_client", "TwelveLabsClient"),
+    "TwelveLabsError": (".twelvelabs_client", "TwelveLabsError"),
+    "AnalysisResult": (".twelvelabs_service", "AnalysisResult"),
+    "AnalysisServiceError": (".twelvelabs_service", "AnalysisServiceError"),
+    "RecordingNotFoundError": (".twelvelabs_service", "RecordingNotFoundError"),
+    "TwelveLabsAnalysisService": (".twelvelabs_service", "TwelveLabsAnalysisService"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attr_name = _EXPORTS[name]
+    except KeyError as exc:  # pragma: no cover - mirrors default module behaviour
+        raise AttributeError(f"module 'jetson' has no attribute {name!r}") from exc
+    module = import_module(module_name, __name__)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value


### PR DESCRIPTION
## Summary
- update the Twelve Labs client to import ApiError from the SDK's new location
- lazily expose jetson module exports so running `python -m jetson.twelvelabs_client` no longer triggers runpy warnings
- treat httpx transport failures from the Twelve Labs SDK the same as ApiError to surface connection reset issues as TwelveLabsError

## Testing
- python -m compileall jetson

------
https://chatgpt.com/codex/tasks/task_e_68d9dd1c1f54832cbf72193ea4a76478