### PR TITLE
Clarify GitHub-based TwelveLabs SDK setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore local copies of the TwelveLabs Python SDK
+third_party/twelvelabs-sdk/

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ ds.startDroneStream();
 ```
 We let the ```DroneStreamManager``` instantiate an instance of ```DroneStream``` for us and invoke the ```startDroneStream()``` afterwards. Please notice the arguments for creating a drone stream; the socket ID and the video tag ID. The socket ID will be the ID belonging to the android application that is assigned when connecting to our signaling server. This is to let our signaling server know where to pass the message when it receives it. We also provide the function with the ID of the HTML video tag, so the drone stream object knows which DOM element to render the video to once it has it.
 
+### TwelveLabs Index Integration
+
+To generate AI video indexes without relying on PyPI, follow the instructions in [`docs/TwelveLabsIndexSetup.md`](docs/TwelveLabsIndexSetup.md). The guide explains how to download the TwelveLabs Python SDK directly from GitHub, where to place the SDK files within this repository, and how to run the accompanying helper script.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- LICENSE -->

--- a/docs/TwelveLabsIndexSetup.md
+++ b/docs/TwelveLabsIndexSetup.md
@@ -1,0 +1,55 @@
+# TwelveLabs Index SDK Setup
+
+이 문서는 TwelveLabs Python SDK를 PyPI 대신 GitHub 저장소에서 직접 내려받아 인덱스를 생성하는 방법을 정리한 것입니다.
+
+## 1. GitHub에서 SDK 내려받기
+
+1. 저장소를 클론하거나 아카이브(zip) 파일을 다운로드합니다.
+   ```bash
+   git clone https://github.com/twelvelabs-io/twelvelabs-python.git
+   ```
+2. 클론한 저장소 안의 `src/twelvelabs` 디렉터리를 통째로 복사하여 이 프로젝트의 `third_party/twelvelabs-sdk` 디렉터리 아래에 붙여 넣습니다. (해당 폴더는 버전 관리를 하지 않도록 `.gitignore`에 등록되어 있습니다.)
+3. 필요하다면 예제 스크립트(`examples/index.py` 등)도 함께 참고용으로 복사할 수 있습니다.
+
+> ⚠️ SDK는 압축을 해제한 폴더 형태로 배치해야 하며, wheel(`*.whl`)이나 zip 상태 그대로 두면 Python이 모듈을 찾지 못합니다.
+
+## 2. 의존성 연결
+
+SDK 폴더를 복사한 뒤에는 Python이 `third_party/twelvelabs-sdk/twelvelabs` 모듈을 찾을 수 있도록 경로를 지정해 주어야 합니다. PyPI에서 설치하는 대신 GitHub에서 내려받은 소스 폴더를 직접 참조하는 방식입니다.
+
+가장 간단한 방법은 스크립트를 실행할 때 일시적으로 `PYTHONPATH`를 지정하는 것입니다.
+
+```bash
+PYTHONPATH="third_party/twelvelabs-sdk" python scripts/create_twelvelabs_index.py
+```
+
+또는 셸 초기화 스크립트(`.bashrc`, `.zshrc` 등)에 다음과 같이 등록하여 항상 TwelveLabs SDK 폴더를 경로에 포함시킬 수도 있습니다.
+
+```bash
+export PYTHONPATH="$(pwd)/third_party/twelvelabs-sdk:${PYTHONPATH}"
+```
+
+## 3. API 키 준비
+
+TwelveLabs API를 호출하려면 환경 변수 `API_KEY`에 발급받은 키를 넣어야 합니다.
+
+```bash
+export API_KEY="tlk_XXXXXXXXXXXXXXXX"
+```
+
+## 4. 인덱스 생성 예제 실행
+
+`scripts/create_twelvelabs_index.py` 스크립트는 TwelveLabs의 예제를 기반으로 인덱스를 생성하고 조회하는 플로우를 보여줍니다.
+
+```bash
+PYTHONPATH="third_party/twelvelabs-sdk" python scripts/create_twelvelabs_index.py
+```
+
+스크립트는 다음 작업을 수행합니다.
+
+- 새로운 인덱스를 생성하고 ID를 출력합니다.
+- 방금 생성한 인덱스를 조회합니다.
+- 인덱스 이름을 갱신합니다.
+- 현재 계정에 존재하는 모든 인덱스를 나열합니다.
+
+이 과정을 통해 GitHub에서 내려받은 SDK가 올바르게 연결되었는지 확인할 수 있습니다.

--- a/scripts/create_twelvelabs_index.py
+++ b/scripts/create_twelvelabs_index.py
@@ -1,0 +1,49 @@
+"""Helper script to create a TwelveLabs index using the locally downloaded SDK."""
+
+import os
+import uuid
+
+from twelvelabs import TwelveLabs
+from twelvelabs.indexes import IndexesCreateRequestModelsItem
+
+
+def create_index() -> None:
+    api_key = os.getenv("API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Missing API_KEY environment variable. Set it before running the script."
+        )
+
+    with TwelveLabs(api_key=api_key) as client:
+        index = client.indexes.create(
+            index_name=f"idx-{uuid.uuid4()}",
+            models=[
+                IndexesCreateRequestModelsItem(
+                    model_name="marengo2.7", model_options=["visual", "audio"]
+                ),
+                IndexesCreateRequestModelsItem(
+                    model_name="pegasus1.2", model_options=["visual", "audio"]
+                ),
+            ],
+            addons=["thumbnail"],
+        )
+        print(f"Created index: id={index.id}")
+
+        retrieved = client.indexes.retrieve(index_id=index.id)
+        print(f"Retrieved index: id={retrieved.id} name={retrieved.index_name}")
+
+        updated_name = f"idx-{uuid.uuid4()}"
+        client.indexes.update(index_id=index.id, index_name=updated_name)
+
+        updated = client.indexes.retrieve(index_id=index.id)
+        print(f"Updated index name to {updated.index_name}")
+
+        print("All indexes registered to the account:")
+        for entry in client.indexes.list():
+            print(
+                f"  id={entry.id} name={entry.index_name} created_at={entry.created_at}"
+            )
+
+
+if __name__ == "__main__":
+    create_index()


### PR DESCRIPTION
## Summary
- clarify that the TwelveLabs SDK should be sourced directly from the GitHub repository
- explain how to point PYTHONPATH to the copied SDK folder instead of installing with pip

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da48c22c9c832c97557f7a1688591c