### PR TITLE
Fix dashboard embedding flow

### DIFF
--- a/jetson/websocket_server.py
+++ b/jetson/websocket_server.py
@@ -879,6 +879,11 @@ class DetectionBroadcaster:
                     embedding_options=embedding_options or None,
                     include_transcription=bool(include_transcription),
                 )
+            except RecordingNotFoundError as exc:
+                return self._json_response(
+                    {"error": "recording_not_found", "message": str(exc)},
+                    status=http.HTTPStatus.NOT_FOUND,
+                )
             except AnalysisServiceError as exc:
                 return self._json_response(
                     {"error": "embedding_failed", "message": str(exc)},


### PR DESCRIPTION
## Summary
- ensure the dashboard embedding button requests embeddings directly and no longer starts an analysis run first
- support query-parameter driven embedding request options and reuse them when issuing the fetch
- improve the analysis service handler to return a 404 when the requested recording is missing during an embeddings request

## Testing
- python -m compileall jetson/websocket_server.py

------
https://chatgpt.com/codex/tasks/task_e_68ddc447f42c832cab56efe6438ddf08