### PR TITLE
Fix cached analysis readiness and gist invocation

### DIFF
--- a/browser/dashboard.js
+++ b/browser/dashboard.js
@@ -491,6 +491,14 @@ function resolveAnalysisViewState(recording, record, defaultStatus, baseMessage,
       cached,
     };
   }
+  const hasAnalysis = recordHasAnalysisContent(record);
+  if (!hasAnalysis) {
+    return {
+      status: 'ready',
+      message: baseMessage || defaultAnalysisMessage,
+      cached,
+    };
+  }
   let normalisedStatus = defaultStatus || (cached ? 'cached' : 'ready');
   if (normalisedStatus === 'pending') {
     normalisedStatus = 'embedding';
@@ -1070,6 +1078,11 @@ function buildAnalysisCompleteMessage(record, cached) {
     return cached
       ? 'Showing stored Twelve Labs analysis.'
       : 'Twelve Labs analysis completed.';
+  }
+  if (!recordHasAnalysisContent(record)) {
+    return cached
+      ? 'No stored Twelve Labs analysis is available yet. Press “Analyze” to generate insights.'
+      : 'Twelve Labs analysis has not been generated yet. Press “Analyze” to request insights.';
   }
   const updatedAt =
     typeof record.updatedAt === 'string' && record.updatedAt ? new Date(record.updatedAt) : null;
@@ -1870,7 +1883,6 @@ function createEmbeddingsBlock(record, cached) {
         typeof segment.embedding_option === 'string' && segment.embedding_option
           ? segment.embedding_option
           : '';
-      const scopeLabel = formatEmbeddingOptionLabel(scope);
       const rangeParts = [];
       if (start !== null) {
         rangeParts.push(`${start.toFixed(1)}s`);
@@ -1881,9 +1893,6 @@ function createEmbeddingsBlock(record, cached) {
       const labelParts = [];
       if (rangeParts.length > 0) {
         labelParts.push(rangeParts.join(' – '));
-      }
-      if (scope) {
-        labelParts.push(scopeLabel || scope);
       }
       header.textContent = labelParts.length > 0 ? labelParts.join(' · ') : `Segment ${index + 1}`;
       segmentBlock.appendChild(header);

--- a/jetson/twelvelabs_service.py
+++ b/jetson/twelvelabs_service.py
@@ -446,9 +446,9 @@ class TwelveLabsAnalysisService:
         if not prompt_value:
             prompt_value = self._default_prompt
 
-        gist_payload = self._client.gist(
+        gist_payload = self._client.fetch_gist(
             video_id=video_id,
-            types=self._gist_types,
+            gist_types=self._gist_types,
         )
 
         if isinstance(gist_payload, dict):


### PR DESCRIPTION
## Summary
- prevent the dashboard from treating embedding-only cached records as completed analysis and improve messaging
- call TwelveLabsClient.fetch_gist when retrieving gist data to match the client API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddda8f6ddc832c8a5b9e5c79e59489