### PR TITLE
Render Twelve Labs summaries and insights on dashboard

### DIFF
--- a/browser/dashboard.html
+++ b/browser/dashboard.html
@@ -446,6 +446,34 @@
       font-size: 0.85rem;
     }
 
+    .analysis-output-body ul {
+      margin: 0;
+      padding-left: 1.1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .analysis-output-body li {
+      margin: 0;
+    }
+
+    .analysis-output-label {
+      font-weight: 600;
+      color: #cbd5f5;
+    }
+
+    .analysis-insight-item {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .analysis-insight-item-title {
+      font-weight: 600;
+      color: #cbd5f5;
+    }
+
     .analysis-meta-grid {
       display: grid;
       grid-template-columns: minmax(120px, 0.4fr) minmax(180px, 1fr);
@@ -497,40 +525,6 @@
     .analysis-video-note a,
     .analysis-embedding-note a {
       color: #5eead4;
-    }
-
-    .embedding-segments {
-      display: flex;
-      flex-direction: column;
-      gap: 0.65rem;
-    }
-
-    .embedding-segment {
-      background: rgba(15, 23, 42, 0.55);
-      border: 1px solid rgba(148, 163, 184, 0.18);
-      border-radius: 8px;
-      padding: 0.6rem 0.75rem;
-      display: flex;
-      flex-direction: column;
-      gap: 0.35rem;
-    }
-
-    .embedding-segment-header {
-      font-weight: 600;
-      font-size: 0.85rem;
-      color: #cbd5f5;
-    }
-
-    .embedding-preview {
-      margin: 0;
-      font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace;
-      font-size: 0.75rem;
-      background: rgba(15, 23, 42, 0.7);
-      border-radius: 6px;
-      border: 1px solid rgba(148, 163, 184, 0.15);
-      padding: 0.4rem 0.5rem;
-      overflow-x: auto;
-      color: #e2e8f0;
     }
 
     video,


### PR DESCRIPTION
## Summary
- remove the unused embedding segment styles from the dashboard layout
- add styling for rendering analysis summaries and insight lists
- surface summary and insight data in the analysis panel with JSON fallbacks when needed

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68dddf2c32bc832ca6ffcf6482477d02