### PR TITLE
Fix Twelve Labs analysis rendering and polling cadence

### DIFF
--- a/jetson/twelvelabs_service.py
+++ b/jetson/twelvelabs_service.py
@@ -567,7 +567,7 @@ class TwelveLabsAnalysisService:
                 chunk_texts.append(cleaned.strip())
 
             analysis_chunks = [chunk for chunk in chunk_texts if chunk]
-            combined_text = " ".join(analysis_chunks)
+            combined_text = "".join(analysis_chunks)
             analysis_text = AnalysisText(text=combined_text, chunks=analysis_chunks)
 
             timestamp = _utc_now()


### PR DESCRIPTION
## Summary
- avoid inserting extra spaces when combining analysis chunks on the server
- prefer the combined analysis text when rendering results in the dashboard so chunks no longer force separate paragraphs
- wait 30 seconds before the dashboard issues the first Twelve Labs status poll, then poll every 5 seconds thereafter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dded97dd2c832c888ec04e42921788