### PR TITLE
Prevent re-requesting embeddings during pending state

### DIFF
--- a/browser/dashboard.html
+++ b/browser/dashboard.html
@@ -278,6 +278,13 @@
       align-items: center;
     }
 
+    .recording-status-detail {
+      margin: 0.25rem 0 0;
+      font-size: 0.75rem;
+      color: #94a3b8;
+      line-height: 1.4;
+    }
+
     .recording-action-button {
       align-self: center;
       border: none;


### PR DESCRIPTION
## Summary
- prevent the embeddings action from re-enabling when shared workflow state reports a pending job
- reuse the shared embedding status to keep the button disabled and show the pending message while the request is in flight

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de0d1f2630832cb17a455ca45a41d0