### PR TITLE
Refine analysis status refresh logic

### DIFF
--- a/browser/dashboard.js
+++ b/browser/dashboard.js
@@ -3404,11 +3404,13 @@ function refreshActiveAnalysisStatus(options = {}) {
   if (activeAnalysisPromise) {
     return;
   }
-  updateAnalysisPanelForRecording(recording, { preserveExistingResult: true });
+
   if (!force && !shouldPollAnalysisStatus(recording)) {
     return;
   }
-  void loadCachedAnalysis(recording);
+
+  updateAnalysisPanelForRecording(recording, { preserveExistingResult: true });
+  void loadCachedAnalysis(recording, { force });
 }
 
 function setSelectedRecording(recording, options = {}) {


### PR DESCRIPTION
## Summary
- prevent the periodic status refresher from overriding embedding state updates when no polling is required
- ensure forced refreshes still update the panel and cached analysis consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de3473c8e4832c80e2269d572f338e